### PR TITLE
Fix typo in macro definition

### DIFF
--- a/freertos/hello_freertos/hello_freertos.c
+++ b/freertos/hello_freertos/hello_freertos.c
@@ -22,7 +22,7 @@
 #endif
 
 // Whether to flash the led
-#ifndef USB_LED
+#ifndef USE_LED
 #define USE_LED 1
 #endif
 


### PR DESCRIPTION
The `#ifndef` checked for `USB_LED` and then defines `USE_LED`. Presumably the `#ifndef` is supposed to check for `USE_LED` instead and then define it if not found.